### PR TITLE
Add some configuration info in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,6 +11,12 @@ the dired buffer:
 
 * Installation
 
+** MELPA
+
+[[https://melpa.org/#/getting-started][Set up MELPA]], then install via =M-x package-install RET dired-git-info=
+
+** Manual
+
 For manual installation, clone the repository and call:
 
 #+BEGIN_SRC elisp
@@ -19,9 +25,30 @@ For manual installation, clone the repository and call:
 
 * Config
 
-Bind the minor mode command in dired:
+** Bind the minor mode command in dired
 
 #+BEGIN_SRC elisp
 (with-eval-after-load 'dired
   (define-key dired-mode-map ")" 'dired-git-info-mode))
+#+END_SRC
+
+** Don't hide normal Dired file info
+
+By default, toggling =dired-git-info-mode= also toggles the built-in =dired-hide-details-mode=, which hides file details such as ownership, permissions and size. This behaviour can be disabled by overriding =dgi-auto-hide-details-p=:
+
+#+BEGIN_SRC elisp
+(with-eval-after-load 'dired
+  (setq dgi-auto-hide-details-p nil))
+#+END_SRC
+
+** Enable automatically in every Dired buffer (if in Git repository)
+
+To enable =dired-git-info-mode= whenever you navigate to a Git repository, add the following snippet:
+#+BEGIN_SRC elisp
+(with-eval-after-load 'dired
+  (defun dired-git-info-mode-loose ()
+    "enable 'dired-git-info-mode only if current Dired buffer is in a Git repo"
+    (if (locate-dominating-file "." ".git")
+        (dired-git-info-mode)))
+  (add-hook 'dired-after-readin-hook 'dired-git-info-mode-loose))
 #+END_SRC

--- a/README.org
+++ b/README.org
@@ -11,9 +11,9 @@ the dired buffer:
 
 * Installation
 
-** MELPA
+** ELPA
 
-[[https://melpa.org/#/getting-started][Set up MELPA]], then install via =M-x package-install RET dired-git-info=
+This package is available on [[https://elpa.gnu.org][ELPA]]. You can install it via =M-x package-install RET dired-git-info RET=
 
 ** Manual
 

--- a/README.org
+++ b/README.org
@@ -46,9 +46,5 @@ By default, toggling =dired-git-info-mode= also toggles the built-in =dired-hide
 To enable =dired-git-info-mode= whenever you navigate to a Git repository, add the following snippet:
 #+BEGIN_SRC elisp
 (with-eval-after-load 'dired
-  (defun dired-git-info-mode-loose ()
-    "enable 'dired-git-info-mode only if current Dired buffer is in a Git repo"
-    (if (locate-dominating-file "." ".git")
-        (dired-git-info-mode)))
-  (add-hook 'dired-after-readin-hook 'dired-git-info-mode-loose))
+  (add-hook 'dired-after-readin-hook 'dired-git-info-auto-enable))
 #+END_SRC


### PR DESCRIPTION
Hey! I've added two sections that I happened to want and took way too long to figure out. Also, despite you package being on MELPA, it is quite easy to miss this fact; the readme currently only has a small ELPA logo at the top, so I made it more explicit.

Thanks for your work :)