### PR TITLE
Add configurable spacing between dired and the git info

### DIFF
--- a/README.org
+++ b/README.org
@@ -51,3 +51,10 @@ the following:
 (add-hook 'dired-after-readin-hook 'dired-git-info-auto-enable)
 #+END_SRC
 
+** Set the spacing between the file names and the git info
+
+If you want more room between the ~dired~ filenames and the git information than
+the default 2 spaces, use the following:
+#+BEGIN_SRC elisp
+(setq dgi-spacing 5)
+#+END_SRC

--- a/dired-git-info.el
+++ b/dired-git-info.el
@@ -78,6 +78,10 @@ are (see git-log PRETTY FORMATS for all):
            · %f: sanitized subject line, suitable for a filename"
   :type 'string)
 
+(defcustom dgi-spacing 2
+  "How many spaces between the longest filename and the commit messages"
+  :type 'integer)
+
 (defvar-local dgi--commit-ovs nil
   "Overlays which show the commit messages.")
 
@@ -220,7 +224,7 @@ info format and defaults to `dgi-commit-message-format'."
                    (dired-unmark-all-marks)
                    (dired-toggle-marks)
                    (dired-get-marked-files)))
-           (minspc  (1+ (apply #'max  (dgi--get-dired-files-length files))))
+           (minspc (+ dgi-spacing (apply #'max  (dgi--get-dired-files-length files))))
            (messages (dgi--get-commit-messages files)))
       (save-excursion
         (dolist (file files)


### PR DESCRIPTION
Add a simple configuration option to add more space before we print the git information. I think the one single space is objectively a bit small, so I set the default to 2. I personally would like even more, so I made it a `custom` option.

Thanks for the package - it's neat!