### PR TITLE
fix: subtract used window space from other modes

### DIFF
--- a/dired-git-info.el
+++ b/dired-git-info.el
@@ -183,6 +183,7 @@ info format and defaults to `dgi-commit-message-format'."
   "Format message MSG for current dired line."
   (let* ((le (line-end-position))
          (aw (- (window-width)
+                (* 2(- (window-total-width) (window-width)))
                 (1+ (save-excursion
                       (goto-char le)
                       (current-column))))))


### PR DESCRIPTION
While the changes successfully address the issue visible in the picture, I want to acknowledge that I may not fully understand the underlying reasons for their effectiveness.

before the change:
![image](https://github.com/clemera/dired-git-info/assets/67476972/6f0a6cda-3a99-401f-9ddb-afa953a19ee5)

after change:
![image](https://github.com/clemera/dired-git-info/assets/67476972/1014cd70-f549-4dce-9f10-faa188ce23e2)

after window resize:
![image](https://github.com/clemera/dired-git-info/assets/67476972/dee92ebe-0e0b-4e69-9b63-61ab57485614)
