### PR TITLE
Fix: empty folder error

### DIFF
--- a/dired-git-info.el
+++ b/dired-git-info.el
@@ -220,7 +220,9 @@ info format and defaults to `dgi-commit-message-format'."
                    (dired-unmark-all-marks)
                    (dired-toggle-marks)
                    (dired-get-marked-files)))
-           (minspc  (1+ (apply #'max  (dgi--get-dired-files-length files))))
+           (minspc  (if files
+                        (1+ (apply #'max (dgi--get-dired-files-length files)))
+                      0))
            (messages (dgi--get-commit-messages files)))
       (save-excursion
         (dolist (file files)


### PR DESCRIPTION
Currently, empty folders cause an error to be thrown, which prevents navigating into the folder. The cause of this is that `max` expects at least one argument.

This change protects against that case, which fixes the error.